### PR TITLE
Add prerendering delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ![Github Actions CI](https://github.com/sanfrancesco/prerendercloud-server/actions/workflows/node.js.yml/badge.svg)
 
+Dockerhub: https://hub.docker.com/r/prerendercloud/webserver
+
 This package is a Node.js pushstate http server powered by [Headless-Render-API.com](https://headless-render-api.com) (formerly named prerender.cloud from 2016 - 2022). It's also the actual server hosting the headless-render-api.com domain (via fly.io).
 
 Use it for server-side rendering (also known as pre-rendering or dynamic rendering) your single-page JavaScript application (React, Angular, Ember, Preact, Vue, etc.)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ docker run \
   - most common use case: configure your DNS to point apex and www to `example.com`, set `CANONICAL_HOST=example.com`, and requests to www.example.com will redirect to apex
   - override the header used to detect host with `HOST_HEADER` (defaults to `host`, if on AWS behind ALB, set `HOST_HEADER=x-forwarded-proto`)
 - `CRAWL_HOST` - if using `--crawl-whitelist-on-boot`, e.g. `CRAWL_HOST=example.com` (no protocol, no slashes)
-  - use with `CRAWL_DELAY_SECONDS` to give your process enough time to boot and go live (35s is a safe/common value)
+  - use with `DISABLE_PRERENDERING_FOR_SECONDS` to give your process enough time to boot and go live (35s is a safe/common value)
+- `DISABLE_PRERENDERING_FOR_SECONDS` is null by default, but if you're running in production with zero-downtime deploys (Kubernetes, Nomad, Fly.io, AWS Beanstalk, etc.), then set this to avoid initial requests hitting the old version of your app during the deploy
 - `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` if using s3 proxy
 
 #### Options

--- a/example-wwwhttp/_start-with-crawl.sh
+++ b/example-wwwhttp/_start-with-crawl.sh
@@ -1,0 +1,1 @@
+CRAWL_HOST=localhost:9000 DISABLE_PRERENDERING_FOR_SECONDS=10 DEBUG=prerendercloud node ../src/bin/prerendercloud-server.js --crawl-whitelist-on-boot

--- a/example-wwwhttp/_start.sh
+++ b/example-wwwhttp/_start.sh
@@ -1,0 +1,1 @@
+DISABLE_PRERENDERING_FOR_SECONDS=10 DEBUG=prerendercloud node ../src/bin/prerendercloud-server.js

--- a/example-wwwhttp/_whitelist.js
+++ b/example-wwwhttp/_whitelist.js
@@ -1,0 +1,6 @@
+// strings or regexes
+// module.exports = ["/", /\/users\/\d{1,6}\/profile\/?$/];
+
+// if this file doesn't exist or the array is empty, any requested path will be pre-rendered
+module.exports = ["/docs", "/"];
+

--- a/example-wwwhttp/index.html
+++ b/example-wwwhttp/index.html
@@ -1,0 +1,1 @@
+hello world example-wwwhttp

--- a/examples/fly-io/Dockerfile
+++ b/examples/fly-io/Dockerfile
@@ -1,3 +1,3 @@
 FROM prerendercloud/webserver:latest
 COPY build /wwwroot
-CMD ["--enable-middleware-cache"]
+CMD ["--enable-middleware-cache", "--ignore-all-query-params", "--crawl-whitelist-on-boot", "--disable-ajax-bypass"]

--- a/examples/fly-io/fly.toml
+++ b/examples/fly-io/fly.toml
@@ -4,7 +4,7 @@
 # OPTIONAL:
 # 1. optionally set CANONICAL_HOST to your actual domain name e.g. www.example.com, then if you have apex example.com also pointed here, it will redirect to www.example.com
 # 2. optionally set CRAWL_HOST to your actual domain name e.g. www.example.com, use with `--crawl-whitelist-on-boot` (see readme)
-# 3. if using CRAWL_HOST, set CRAWL_DELAY_SECONDS to "30" (it takes approximately 30s for fly.io to finish booting)
+# 3. set DISABLE_PRERENDERING_FOR_SECONDS to "40" to give fly.io deploys enough time to finish before pre-rendering (to avoid pre-rendering the old version)
 
 app = "placeholder-for-your-actual-fly-app-name"
 
@@ -16,7 +16,7 @@ processes = []
   PRERENDER_TOKEN = ""
   CANONICAL_HOST=""
   CRAWL_HOST=""
-  CRAWL_DELAY_SECONDS=""
+  DISABLE_PRERENDERING_FOR_SECONDS="40"
 
 [experimental]
   allowed_public_ports = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerendercloud-server",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Headless-Render-API pre-rendering, pushstate web server",
   "main": "./src/bin/prerendercloud-server.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -136,19 +136,25 @@ exports.start = function (options, _onStarted) {
 
   const crawlAtBootEnabled =
     whitelist && options["--crawl-whitelist-on-boot"] && process.env.CRAWL_HOST;
-  const parsedCrawlDelaySeconds =
-    crawlAtBootEnabled && parseInt(process.env.CRAWL_DELAY_SECONDS);
+  const parsedDisablePrerenderingSeconds = parseInt(
+    process.env.DISABLE_PRERENDERING_FOR_SECONDS ||
+      process.env.CRAWL_DELAY_SECONDS
+  );
   const bootedAt = Date.now();
 
-  if (parsedCrawlDelaySeconds && parsedCrawlDelaySeconds > 0) {
+  if (
+    parsedDisablePrerenderingSeconds &&
+    parsedDisablePrerenderingSeconds > 0
+  ) {
     let isEnabled = false;
     prerendercloud.set("shouldPrerenderAdditionalCheck", function (req) {
       isEnabledWas = isEnabled;
       isEnabled =
-        new Date() > new Date(bootedAt + parsedCrawlDelaySeconds * 1000);
+        new Date() >
+        new Date(bootedAt + parsedDisablePrerenderingSeconds * 1000);
       if (isEnabled && !isEnabledWas) {
         console.log(
-          "first pre-rendering request since crawl delay was enabled, proceeding"
+          "first pre-rendering request since DISABLE_PRERENDERING_FOR_SECONDS was enabled, proceeding"
         );
       }
 
@@ -210,19 +216,24 @@ exports.start = function (options, _onStarted) {
         }
       );
 
-    if (!parsedCrawlDelaySeconds || parsedCrawlDelaySeconds <= 0) {
+    if (
+      !parsedDisablePrerenderingSeconds ||
+      parsedDisablePrerenderingSeconds <= 0
+    ) {
       return p();
     }
     console.log(
-      "NOTICE: CRAWL_DELAY_SECONDS configured, waiting",
-      parsedCrawlDelaySeconds,
+      "NOTICE: DISABLE_PRERENDERING_FOR_SECONDS configured, waiting",
+      parsedDisablePrerenderingSeconds,
       "seconds before crawling"
     );
 
     const buffer = 1000;
-    const delayMs = parsedCrawlDelaySeconds * 1000 + buffer;
+    const delayMs = parsedDisablePrerenderingSeconds * 1000 + buffer;
     setTimeout(() => {
-      console.log("CRAWL_DELAY_SECONDS elapsed, commencing crawl whitelist");
+      console.log(
+        "DISABLE_PRERENDERING_FOR_SECONDS elapsed, commencing crawl whitelist"
+      );
 
       p();
     }, delayMs);


### PR DESCRIPTION
1. rename CRAWL_DELAY_SECONDS to DISABLE_PRERENDERING_FOR_SECONDS
2. make it work not just when crawling, but for normal lazy load pre-renders too

Fixes a bug during deploys by delaying it for ~40s (e.g. zero-downtime deploy where a load balancer is serving 2 versions of your app at the same time, the new version requests a pre-render, and headless-render-api gets served the old version from the load balancer).