### PR TITLE
Fixes bug causing redirects to be followed even if false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prerendercloud-server",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prerendercloud-server",
-      "version": "0.8.6",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.7.4",
@@ -14,13 +14,13 @@
         "connect-static-file": "2.0.0",
         "debug": "^4.3.4",
         "got-lite": "^8.0.4",
-        "prerendercloud": "^1.46.3",
+        "prerendercloud": "^1.47.0",
         "s3-proxy": "^1.2.1",
         "serve-static": "1.15.0",
         "update-notifier": "^5.1.0"
       },
       "bin": {
-        "prerendercloud-server": "dist/bin/prerendercloud-server"
+        "prerendercloud-server": "src/bin/prerendercloud-server.js"
       },
       "devDependencies": {
         "jasmine": "^4.1.0",
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/prerendercloud": {
-      "version": "1.46.3",
-      "resolved": "https://registry.npmjs.org/prerendercloud/-/prerendercloud-1.46.3.tgz",
-      "integrity": "sha512-Uh5vXNCDlThsV9Z4XIIKrGeSsdvB3pyBnkwWouvnZqOJIn4ZWiG7MqHUJJPLux1Nh2SC6FuXQcjIoW2f673d9Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/prerendercloud/-/prerendercloud-1.47.0.tgz",
+      "integrity": "sha512-jcvb462VOJv9Uw5P99nNe4GxEM2gNpdOzPvoB6/p+olu6xdMySVvvboX2L3jf96BDdUwZ46uIr9SCdgNGwfEXw==",
       "dependencies": {
         "debug": "^4.3.4",
         "got-lite": "^8.0.4",
@@ -3553,9 +3553,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prerendercloud": {
-      "version": "1.46.3",
-      "resolved": "https://registry.npmjs.org/prerendercloud/-/prerendercloud-1.46.3.tgz",
-      "integrity": "sha512-Uh5vXNCDlThsV9Z4XIIKrGeSsdvB3pyBnkwWouvnZqOJIn4ZWiG7MqHUJJPLux1Nh2SC6FuXQcjIoW2f673d9Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/prerendercloud/-/prerendercloud-1.47.0.tgz",
+      "integrity": "sha512-jcvb462VOJv9Uw5P99nNe4GxEM2gNpdOzPvoB6/p+olu6xdMySVvvboX2L3jf96BDdUwZ46uIr9SCdgNGwfEXw==",
       "requires": {
         "debug": "^4.3.4",
         "got-lite": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerendercloud-server",
-  "version": "0.8.12",
+  "version": "0.9.0",
   "description": "Headless-Render-API pre-rendering, pushstate web server",
   "main": "./src/bin/prerendercloud-server.js",
   "repository": {
@@ -26,7 +26,7 @@
     "connect-static-file": "2.0.0",
     "debug": "^4.3.4",
     "got-lite": "^8.0.4",
-    "prerendercloud": "^1.46.3",
+    "prerendercloud": "^1.47.0",
     "s3-proxy": "^1.2.1",
     "serve-static": "1.15.0",
     "update-notifier": "^5.1.0"


### PR DESCRIPTION
If the user does not specify --follow-redirects, it defaults to false so the redirect can be returned the end-user (or search crawler) so it can interpret the 301/302 correctly.

More info, see fix in underlying core dependency https://github.com/sanfrancesco/prerendercloud-nodejs/pull/38